### PR TITLE
feat(api): Change API to match Firebase 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Querybase takes a Firebase references with a list of fields to create composite 
  // Get a reference to the database service
  const database = firebase.database();
  const databaseRef = database.ref().child('people');
- const querybaseRef = new Querybase(databaseRef, ['name', 'age', 'location']);
+ const querybaseRef = querybase.ref(databaseRef, ['name', 'age', 'location']);
  
  // Automatically handles composite keys
  querybaseRef.push({ 

--- a/examples/index.html
+++ b/examples/index.html
@@ -23,7 +23,7 @@
 
 		var ref = firebase.database().ref();
 		var peopleRef = ref.child("people");
-		var queryRef = new Querybase(peopleRef, ['name', 'age', 'location', 'weight']);
+		var queryRef = querybase.ref(peopleRef, ['name', 'age', 'location', 'weight']);
 		
 		btnSeed.addEventListener('click', function(e) {
 			peopleRef.remove();
@@ -51,6 +51,7 @@
 				weight: weight
 			});
 		}
+			
 	</script>
 
 </body>

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,7 +1,0 @@
-const Querybase = require('./Querybase');
-const Firebase = require('firebase');
-
-const FirebaseUrl = 'https://querybase.firebaseio-demo.com/';
-
-const ref = new Firebase(FirebaseUrl).child('people');
-const queryRef = new Querybase(ref, ['height', 'name', 'age']);

--- a/src/querybase.ts
+++ b/src/querybase.ts
@@ -166,7 +166,8 @@ const _: QuerybaseUtils = {
  * 
  * @example
  *  // Querybase for multiple equivalency
- *  const firebaseRef = new Firebase('<my-app>/people');
+ *  const database = firebase.database();
+ *  const firebaseRef = database.ref().child('people');
  *  const querybaseRef = new Querybase(firebaseRef, ['name', 'age', 'location']);
  *  
  *  // Automatically handles composite keys
@@ -607,16 +608,25 @@ class QuerybaseQuery {
 
 }
 
+const querybaseExport = {
+  ref: function (ref: Firebase, indexes: string[]) {
+    return new Querybase(ref, indexes);
+  }
+};
+
 // Export the modules for the current environment
 if (_.isCommonJS()) {
-  module.exports = Querybase;
+  module.exports = querybaseExport;
+  module.exports.Querybase = Querybase;
   module.exports.QuerybaseUtils = _;
   module.exports.QuerybaseQuery = QuerybaseQuery;
 } else {
   /* istanbul ignore next */
-  window["Querybase"] = Querybase;
+  window["querybase"] = querybaseExport;
   /* istanbul ignore next */
-  window["Querybase"]["QuerybaseUtils"] = _;
+  window["querybase"]["Querybase"] = Querybase;
   /* istanbul ignore next */
-  window["Querybase"]["QuerybaseQuery"] = QuerybaseQuery;
+  window["querybase"]["QuerybaseUtils"] = _;
+  /* istanbul ignore next */
+  window["querybase"]["QuerybaseQuery"] = QuerybaseQuery;
 }

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,6 +1,7 @@
 "use strict";
-const Querybase = require('../dist/querybase');
-const QuerybaseQuery = Querybase.QuerybaseQuery;
+const querybase = require('../dist/querybase');
+const Querybase = querybase.Querybase;
+const QuerybaseQuery = querybase.QuerybaseQuery;
 
 /**
  * Detects a QuerybaseQuery

--- a/tests/unit/querybase.spec.js
+++ b/tests/unit/querybase.spec.js
@@ -1,17 +1,31 @@
 /// <reference path="../../typings/tsd.d.ts" />
 'use strict'
 const firebaseServer = require('../firebaseServer');
-const Querybase = require('../../dist/querybase');
+const querybase = require('../../dist/querybase');
+const Querybase = querybase.Querybase;
+const QuerybaseQuery = querybase.QuerybaseQuery;
 const helpers = require('../helpers');
-const QuerybaseQuery = Querybase.QuerybaseQuery;
-const _ = Querybase.QuerybaseUtils;
+const _ = querybase.QuerybaseUtils;
 const assert = require('assert');
 const chai = require('chai');
 const sinon = require('sinon');
 const expect = chai.expect;
 
 // disable warnings
+// TODO: Create index rules for the querybase database
 console.warn = () => {};
+
+describe('querybase export', () => {
+  
+  const ref = firebaseServer.ref().child('items');
+  const indexes = ['color', 'height', 'weight'];
+  
+  it('should create a Querybase ref', () => {
+    const queryRef = querybase.ref(ref, indexes)
+    assert.equal(true, helpers.isQuerybaseRef(queryRef));
+  });
+  
+});
 
 describe('Querybase', () => {
 


### PR DESCRIPTION
Instead of 

``` js
const ref = new Firebase('');
const querybaseRef = new Querybase(ref, ['name', 'age', 'location']);
```

You will now do this:

``` js
const ref =  firebase.database.ref();
const querybaseRef = querybase.ref(ref, ['name', 'age', 'location']);
```
