### PR TITLE
fix(keys): Change _ key to ~~ key

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Documentation
 
-Querybase takes a Firebase references with a list of fields to create composite keys. 
+Querybase takes a Firebase Database reference with a list of fields to create composite keys. 
 
 ### Querying using multiple fields
 
@@ -47,7 +47,7 @@ querybaseRef
     name: 'David',
     age: 27
   })
-  // returns a Firebase ref
+  // returns a Firebase Database ref
   .on('value', (snap) => {
     console.log(snap);
   });
@@ -57,6 +57,10 @@ querybaseRef
 ### Querying using one field
  
  ```js
+  // Get a reference to the database service
+ const database = firebase.database();
+ const databaseRef = database.ref().child('people');
+ const queryRef = querybase.query(databaseRef);
  // Querybase for single criteria, returns a Firebase Ref
  querybaseRef.where({ name: 'David'});
   

--- a/src/querybase.ts
+++ b/src/querybase.ts
@@ -72,7 +72,7 @@ const _: QuerybaseUtils = {
    * @return {string}
    */
   createKey(propOne, propTwo) {
-    return `${propOne}_${propTwo}`;
+    return `${propOne}~~${propTwo}`;
   },
 
   /**
@@ -166,8 +166,7 @@ const _: QuerybaseUtils = {
  * 
  * @example
  *  // Querybase for multiple equivalency
- *  const database = firebase.database();
- *  const firebaseRef = database.ref().child('people');
+ *  const firebaseRef = new Firebase('<my-app>/people');
  *  const querybaseRef = new Querybase(firebaseRef, ['name', 'age', 'location']);
  *  
  *  // Automatically handles composite keys
@@ -335,8 +334,8 @@ class Querybase {
 
     // for multiple criteria in the object, 
     // encode the keys and values provided
-    const criteriaIndex = this.encodeKey(keys.join('_'));
-    const criteriaValues = this.encodeKey(values.join('_'));
+    const criteriaIndex = this.encodeKey(keys.join('~~'));
+    const criteriaValues = this.encodeKey(values.join('~~'));
 
     return {
       predicate: criteriaIndex,
@@ -501,7 +500,7 @@ class Querybase {
    * @return {string}
    */
   encodeKey(value: string): string {
-    return "querybase_" + _.encodeBase64(value);
+    return "querybase~~" + _.encodeBase64(value);
   }
 
   /**
@@ -526,7 +525,7 @@ class Querybase {
 "${_.getPathFromRef(this.ref())}": {
   "._indexOn": [${_.keys(indexKeys).map((key) => { return `"${indexKeys[key]}"`; }).join(", ")}]
 }`;
-    console.warn(`Add this rule to drastically improve performance of your Firebase queries: \n ${_indexOnRule}`);
+    console.warn(`Add this rule to drastically improve performance of your Realtime Database queries: \n ${_indexOnRule}`);
   }
 
 }

--- a/tests/unit/querybase.spec.js
+++ b/tests/unit/querybase.spec.js
@@ -32,10 +32,10 @@ describe('Querybase', () => {
   const ref = firebaseServer.ref().child('items');
   const indexes = ['color', 'height', 'weight'];
   const expectedIndex = {
-    'color_height': 'Blue_67',
-    'color_height_weight': 'Blue_67_130',
-    'color_weight': 'Blue_130',
-    'height_weight': '67_130'
+    'color~~height': 'Blue~~67',
+    'color~~height~~weight': 'Blue~~67~~130',
+    'color~~weight': 'Blue~~130',
+    'height~~weight': '67~~130'
   };
   
   let queryRef;
@@ -226,8 +226,8 @@ describe('Querybase', () => {
     it('should encode a QueryPredicate for multiple criteria', () => {
       
       const expectedPredicate = {
-        predicate: 'querybase_Y29sb3JfaGVpZ2h0',
-        value: 'querybase_Qmx1ZV82Nw=='
+        predicate: 'querybase~~Y29sb3J+fmhlaWdodA==',
+        value: 'querybase~~Qmx1ZX5+Njc='
       };
       
       const predicate = queryRef._createQueryPredicate({ color: 'Blue', height: 67 });
@@ -273,11 +273,13 @@ describe('Querybase', () => {
     it('should encode an object', () => {
       
       const expectedEncodedIndex = { 
-        'querybase_Y29sb3JfaGVpZ2h0': 'querybase_Qmx1ZV82Nw==',
-        'querybase_Y29sb3JfaGVpZ2h0X3dlaWdodA==': 'querybase_Qmx1ZV82N18xMzA=',
-        'querybase_Y29sb3Jfd2VpZ2h0': 'querybase_Qmx1ZV8xMzA=',
-        'querybase_aGVpZ2h0X3dlaWdodA==': 'querybase_NjdfMTMw' 
+        'querybase~~Y29sb3J+fmhlaWdodA==': 'querybase~~Qmx1ZX5+Njc=',
+        'querybase~~Y29sb3J+fmhlaWdodH5+d2VpZ2h0': 'querybase~~Qmx1ZX5+Njd+fjEzMA==',
+        'querybase~~Y29sb3J+fndlaWdodA==': 'querybase~~Qmx1ZX5+MTMw',
+        'querybase~~aGVpZ2h0fn53ZWlnaHQ=': 'querybase~~Njd+fjEzMA==' 
       };
+      
+      
       
       const encodedIndex = queryRef._encodeCompositeIndex(expectedIndex);
       assert.deepEqual(expectedEncodedIndex, encodedIndex);
@@ -310,7 +312,7 @@ describe('Querybase', () => {
     
     it('should call the Firebase orderByChild function', () => {
       sinon.spy(queryRef.ref(), 'orderByChild');
-      queryRef._createEqualToQuery({ predicate: 'age_name', value: '27_David' });
+      queryRef._createEqualToQuery({ predicate: 'age~~name', value: '27~~David' });
       expect(queryRef.ref().orderByChild.calledOnce).to.be.ok;
       queryRef.ref().orderByChild.restore();
     });


### PR DESCRIPTION
Internal detail of library. Querybase used to use the `_` character to determine composite keys. Now it uses a uncommon used key `~~`. This will make collisions rare.
