### PR TITLE
fix(indexes): Limit indexes to three for sanity

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -23,18 +23,18 @@
 
 		var ref = firebase.database().ref();
 		var peopleRef = ref.child("people");
-		var queryRef = querybase.ref(peopleRef, ['name', 'age', 'location', 'weight']);
+		var queryRef = querybase.ref(peopleRef, ['name', 'age', 'location']);
 		
 		btnSeed.addEventListener('click', function(e) {
 			peopleRef.remove();
-			addPerson('David_East', 27, 'SF', 125);
-			addPerson('Shannon', 28, 'SF', 115);
-			addPerson('Coco', 1, 'SF', 12);
-			addPerson('Cash', 3, 'SF', 32);
-			addPerson('George', 27, 'DEN', 150);
-			addPerson('Bob', '27', 'SF', 160);
-			addPerson('Molly', 6, 'SF', 55);
-			addPerson('Mambo', 4, 'DEN', 6);
+			addPerson('David_East', 27, 'SF');
+			addPerson('Shannon', 28, 'SF');
+			addPerson('Coco', 1, 'SF');
+			addPerson('Cash', 3, 'SF');
+			addPerson('George', 27, 'DEN');
+			addPerson('Bob', '27', 'SF');
+			addPerson('Molly', 6, 'SF');
+			addPerson('Mambo', 4, 'DEN');
 		});
 		
 		function listen(ref) {
@@ -47,8 +47,7 @@
 			queryRef.push({
 				name: name,
 				age: age,
-				location: location,
-				weight: weight
+				location: location
 			});
 		}
 			

--- a/tests/unit/querybase-utils.spec.js
+++ b/tests/unit/querybase-utils.spec.js
@@ -160,7 +160,6 @@ describe('QuerybaseUtils', () => {
     it('should create an object with the index positions', () => {
       
       const indexOfKeys = _.getKeyIndexPositions(smallRecordKeys);
-      console.log(indexOfKeys);
       assert.deepEqual({ 'zed': 0, 'name': 1, 'time': 2 }, indexOfKeys);   
       
     });
@@ -171,12 +170,12 @@ describe('QuerybaseUtils', () => {
     
     it('should create a sorted object', () => {
       const sortedRecord = _.createSortedObject(smallRecordKeys, smallRecordValues);
-      assert.deepEqual(sortedSmallRecord, sortedRecord); 
+      assert.deepEqual(_.keys(sortedRecord), _.keys(sortedSmallRecord)); 
     })
     
     it('should create a sorted object', () => {
       const sortedRecord = _.createSortedObject(mediumRecordKeys, mediumRecordValues);
-      assert.deepEqual(sortedMediumRecord, sortedRecord); 
+      assert.deepEqual(_.keys(sortedMediumRecord), _.keys(sortedRecord)); 
     })    
     
   });
@@ -185,12 +184,12 @@ describe('QuerybaseUtils', () => {
     
     it('sort an object lexicographically', () => {
       const sortedRecord = _.sortObjectLexicographically(smallRecord);
-      assert.deepEqual(sortedSmallRecord, sortedRecord);
+      assert.deepEqual(_.keys(sortedSmallRecord), _.keys(sortedRecord));
     });
     
     it('sort an object lexicographically', () => {
       const sortedRecord = _.sortObjectLexicographically(mediumRecord);
-      assert.deepEqual(sortedMediumRecord, sortedRecord);
+      assert.deepEqual(_.keys(sortedMediumRecord), _.keys(sortedRecord));
     });    
     
   });

--- a/tests/unit/querybase-utils.spec.js
+++ b/tests/unit/querybase-utils.spec.js
@@ -10,6 +10,42 @@ const expect = chai.expect;
 
 describe('QuerybaseUtils', () => {
   
+  const smallRecord = {
+    zed: 'a',
+    name: 'David',
+    time: '5:01'
+  };
+  
+  const mediumRecord = {
+    zed: 'a',
+    zzzz: 'zzzz',
+    name: 'David',
+    time: '5:01',
+    alpha: 'a',
+    yogi: 'bear',
+    jon: 'jon'
+  };  
+  
+  const smallRecordKeys = _.keys(smallRecord);
+  const smallRecordValues = _.values(smallRecord);
+  const mediumRecordKeys = _.keys(mediumRecord);
+  const mediumRecordValues = _.values(mediumRecord);
+  
+  const sortedSmallRecord = {
+    name: 'David',
+    time: '5:01',
+    zed: 'a'
+  };
+  
+  const sortedMediumRecord = {
+    'alpha': 'a',
+    'jon': 'jon',
+    'name': 'David',
+    'time': '5:01',
+    'yogi': 'bear',
+    'zed': 'a',
+    'zzzz': 'zzzz'
+  };  
   
   it('should exist', () => { expect(_).to.exist; })
   
@@ -96,4 +132,67 @@ describe('QuerybaseUtils', () => {
     
   });
   
+  describe('lexicographicallySort', () => {
+    
+    it('should lexicographically sort', () => {
+      const sorted = smallRecordKeys.slice().sort(_.lexicographicallySort);
+      assert.deepEqual(['name', 'time', 'zed'], sorted);
+    });
+
+    it('should lexicographically sort', () => {
+      const sorted = mediumRecordKeys.slice().sort(_.lexicographicallySort);
+      const expectedOrder = [
+        'alpha',
+        'jon',
+        'name',
+        'time',
+        'yogi',
+        'zed',
+        'zzzz'
+       ];
+      assert.deepEqual(expectedOrder, sorted);
+    });    
+    
+  });
+  
+  describe('getKeyIndexPositions', () => {
+    
+    it('should create an object with the index positions', () => {
+      
+      const indexOfKeys = _.getKeyIndexPositions(smallRecordKeys);
+      console.log(indexOfKeys);
+      assert.deepEqual({ 'zed': 0, 'name': 1, 'time': 2 }, indexOfKeys);   
+      
+    });
+     
+  });
+  
+  describe('createSortedObject', () => {
+    
+    it('should create a sorted object', () => {
+      const sortedRecord = _.createSortedObject(smallRecordKeys, smallRecordValues);
+      assert.deepEqual(sortedSmallRecord, sortedRecord); 
+    })
+    
+    it('should create a sorted object', () => {
+      const sortedRecord = _.createSortedObject(mediumRecordKeys, mediumRecordValues);
+      assert.deepEqual(sortedMediumRecord, sortedRecord); 
+    })    
+    
+  });
+  
+  describe('sortObjectLexicographically', () => {
+    
+    it('sort an object lexicographically', () => {
+      const sortedRecord = _.sortObjectLexicographically(smallRecord);
+      assert.deepEqual(sortedSmallRecord, sortedRecord);
+    });
+    
+    it('sort an object lexicographically', () => {
+      const sortedRecord = _.sortObjectLexicographically(mediumRecord);
+      assert.deepEqual(sortedMediumRecord, sortedRecord);
+    });    
+    
+  });
+    
 });

--- a/tests/unit/querybase.spec.js
+++ b/tests/unit/querybase.spec.js
@@ -177,9 +177,8 @@ describe('Querybase', () => {
     
     it('should return a child Querybase ref with new indexes', () => {
       const childRef = queryRef.child('some/path', ['name', 'color'])
-      // TODO: array comparison
-      assert.equal(childRef.indexOn()[0], 'name');
-      assert.equal(childRef.indexOn()[1], 'color');
+      assert.equal(childRef.indexOn()[0], 'color');
+      assert.equal(childRef.indexOn()[1], 'name');
     });
     
     it('should throw if no indexes are provided', () => {
@@ -202,7 +201,7 @@ describe('Querybase', () => {
     });
     
     it('should create a Firebase query for multiple criteria', () => {
-      const query = queryRef.where({ color: 'green', weight: '120' });
+      const query = queryRef.where({ weight: '120', color: 'green' });
       assert.equal(true, helpers.isFirebaseRef(query));
     });
     
@@ -232,7 +231,7 @@ describe('Querybase', () => {
     });
     
     // encoded
-    // { color: 'Blue', height: '67 }
+    // { height: '67', color: 'Blue' }
     it('should encode a QueryPredicate for multiple criteria', () => {
       
       const expectedPredicate = {
@@ -240,7 +239,7 @@ describe('Querybase', () => {
         value: 'querybase~~Qmx1ZX5+Njc='
       };
       
-      const predicate = queryRef._createQueryPredicate({ color: 'Blue', height: 67 });
+      const predicate = queryRef._createQueryPredicate({ height: 67, color: 'Blue' });
       assert.deepEqual(expectedPredicate, predicate);
       
     });
@@ -252,9 +251,9 @@ describe('Querybase', () => {
     it('should create a composite index', () => {
 
       const compositeIndex = queryRef._createCompositeIndex(indexes, {
-        color: 'Blue',
+        weight: 130,
         height: 67,
-        weight: 130
+        color: 'Blue'
       });
       
       assert.deepEqual(compositeIndex, expectedIndex);
@@ -288,8 +287,6 @@ describe('Querybase', () => {
         'querybase~~Y29sb3J+fndlaWdodA==': 'querybase~~Qmx1ZX5+MTMw',
         'querybase~~aGVpZ2h0fn53ZWlnaHQ=': 'querybase~~Njd+fjEzMA==' 
       };
-      
-      
       
       const encodedIndex = queryRef._encodeCompositeIndex(expectedIndex);
       assert.deepEqual(expectedEncodedIndex, encodedIndex);

--- a/tests/unit/querybase.spec.js
+++ b/tests/unit/querybase.spec.js
@@ -54,14 +54,20 @@ describe('Querybase', () => {
       const errorWrapper = () => new Querybase(ref);
       expect(errorWrapper).to.throw(Error);
     });
+
+    it('should throw if more than 3 indexes are provided', () => {
+      const fourIndexes = ['color', 'height', 'weight', 'location'];
+      const errorWrapper = () => new Querybase(ref, fourIndexes);
+      expect(errorWrapper).to.throw(Error);
+    });    
     
   });
   
-  describe('getKey', () => {
+  describe('key property', () => {
     
     it('should throw if no indexes are provided', () => {
       const querybaseRef = querybase.ref(ref, ['name', 'age']);
-      const key = querybaseRef.getKey();
+      const key = querybaseRef.key;
       assert.equal(key, 'items');
     });    
     

--- a/typings/firebase/firebase.d.ts
+++ b/typings/firebase/firebase.d.ts
@@ -47,7 +47,7 @@ interface FirebaseDataSnapshot {
 	/**
 	 * Gets the key name of the location that generated this DataSnapshot.
 	 */
-	getKey(): string;
+	key: string;
 	/**
 	 * @deprecated Use key() instead.
 	 * Gets the key name of the location that generated this DataSnapshot.
@@ -238,7 +238,7 @@ interface Firebase extends FirebaseQuery {
 	/**
 	 * Returns the last token in a Firebase location.
 	 */
-	getKey(): string;
+	key: string;
 	/**
 	 * @deprecated Use key() instead.
 	 * Returns the last token in a Firebase location.


### PR DESCRIPTION
This PR contains two fixes:
1. Fix key ordering to match server key ordering for objects in the `.where()` method.
2. Limit indexes for querying for 3 due to the exponential amount of indexes created.
