### PR TITLE
chore(build): Firebase to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sinon": "^1.17.2",
     "typescript": "^2.0.10"
   },
-  "dependencies": {
-    "firebase": "^3.6.1"
+  "peerDependencies": {
+    "firebase": "^3.0.0"
   }
 }


### PR DESCRIPTION
Firebase should be a peer dependency as any version above 3.0 will work with Querybase.