### PR TITLE
chore(tests): Change tests to TypeScript for the greater good

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,9 @@ logos
 examples
 coverage
 es6
+tests
+dist/tests
+dist/entry.js
+dist/querybase.js
+dist/QuerybaseQuery.js
+dist/QuerybaseUtils.js

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "dist"
   ],
   "devDependencies": {
+    "@types/chai": "^3.4.34",
+    "@types/mocha": "^2.2.35",
     "@types/node": "^6.0.51",
+    "@types/sinon": "^1.16.34",
     "chai": "^3.4.1",
     "coveralls": "^2.11.9",
     "del": "^2.2.0",

--- a/src/QuerybaseQuery.ts
+++ b/src/QuerybaseQuery.ts
@@ -23,7 +23,7 @@ export type DatabaseQuery = firebase.database.Query;
 export class QuerybaseQuery {
 
   // read-only DatabaseQuery
-  private query: () => DatabaseQuery;
+  public query: () => DatabaseQuery;
 
   constructor(query: DatabaseQuery) {
     this.query = () => query;

--- a/src/tests/firebaseServer.js
+++ b/src/tests/firebaseServer.js
@@ -1,0 +1,27 @@
+const firebase = require("firebase");
+
+/**
+ * Initialize the app with a service account, granting admin privileges
+ */
+function initializeApp() {
+  firebase.initializeApp({
+    databaseURL: "https://querybase-b565d.firebaseio.com"
+  });
+}
+
+/**
+ * Creates a root ref for the database that is offline
+ */
+function getRef() {
+  const db = firebase.database();
+
+  // go offline for testing
+  db.goOffline();
+
+  return db.ref();
+}
+
+module.exports = {
+  ref: getRef,
+  initializeApp: initializeApp
+};

--- a/src/tests/firebaseServer.ts
+++ b/src/tests/firebaseServer.ts
@@ -1,4 +1,4 @@
-const firebase = require("firebase");
+import * as firebase from 'firebase';
 
 /**
  * Initialize the app with a service account, granting admin privileges
@@ -6,7 +6,7 @@ const firebase = require("firebase");
 function initializeApp() {
   firebase.initializeApp({
     databaseURL: "https://querybase-b565d.firebaseio.com"
-  }); 
+  });
 }
 
 /**
@@ -14,14 +14,14 @@ function initializeApp() {
  */
 function getRef() {
   const db = firebase.database();
-  
+
   // go offline for testing
   db.goOffline();
-  
+
   return db.ref();
 }
 
-module.exports = {
-  ref: getRef,
-  initializeApp: initializeApp
+export {
+  getRef as ref,
+  initializeApp
 };

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -1,5 +1,5 @@
 "use strict";
-const querybase = require('../dist/querybase.umd');
+import * as querybase from '../entry';
 const Querybase = querybase.Querybase;
 const QuerybaseQuery = querybase.QuerybaseQuery;
 
@@ -18,7 +18,7 @@ function isQuerybaseQuery(query) {
  */
 function isQuerybaseRef(ref) {
   const type = Object.getPrototypeOf(ref);
-  return type === Querybase.prototype;  
+  return type === Querybase.prototype;
 }
 
 /**
@@ -47,8 +47,10 @@ function isFirebaseQuery(query) {
   return isFunction(query.startAt);
 }
 
-module.exports.isFunction = isFunction;
-module.exports.isFirebaseRef = isFirebaseRef;
-module.exports.isFirebaseQuery = isFirebaseQuery;
-module.exports.isQuerybaseRef = isQuerybaseRef;
-module.exports.isQuerybaseQuery = isQuerybaseQuery;
+export {
+  isFunction,
+  isFirebaseRef,
+  isFirebaseQuery,
+  isQuerybaseRef,
+  isQuerybaseQuery
+}

--- a/src/tests/unit/querybase-query.spec.ts
+++ b/src/tests/unit/querybase-query.spec.ts
@@ -1,117 +1,117 @@
 'use strict'
 const firebaseServer = require('../firebaseServer');
-const Querybase = require('../../dist/querybase.umd');
-const helpers = require('../helpers');
-const QuerybaseQuery = Querybase.QuerybaseQuery;
-const _ = Querybase.QuerybaseUtils;
-const assert = require('assert');
-const chai = require('chai');
-const sinon = require('sinon');
+import * as querybase from '../../entry';
+import * as helpers from '../helpers';
+import * as assert from 'assert';
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+
+const QuerybaseQuery = querybase.QuerybaseQuery;
 const expect = chai.expect;
 
 describe('QuerybaseQuery', () => {
-  
+
   let queryRef;
   beforeEach(() => queryRef = new QuerybaseQuery(ref.orderByChild('value')));
-  
+
   const ref = firebaseServer.ref().child('items');
-  
+
   describe('constructor', () => {
-    
+
     it('should set a FirebaseQuery', () => {
       const query = ref.orderByChild('value');
       const querybaseQuery = new QuerybaseQuery(query);
       assert.equal(helpers.isFirebaseQuery(querybaseQuery.query()), true);
     });
-    
+
   });
-  
+
   describe('lessThan', () => {
-   
+
     it('should call FirebaseQuery.endAt', () => {
       sinon.spy(queryRef.query(), 'endAt');
       queryRef.lessThan(3);
       expect(queryRef.query().endAt.calledOnce).to.be.ok;
-      queryRef.query().endAt.restore();    
+      queryRef.query().endAt.restore();
     });
-    
+
   });
-  
-  describe('greaterThan', () => {    
-    
+
+  describe('greaterThan', () => {
+
     it('should call FirebaseQuery.startAt', () => {
       sinon.spy(queryRef.query(), 'startAt');
       queryRef.greaterThan(100);
       expect(queryRef.query().startAt.calledOnce).to.be.ok;
-      queryRef.query().startAt.restore();    
-    });    
-    
+      queryRef.query().startAt.restore();
+    });
+
     it('should return a Firebase Query', () => {
       const query = queryRef.greaterThan(3);
-      assert.equal(helpers.isFirebaseQuery(query), true);       
+      assert.equal(helpers.isFirebaseQuery(query), true);
     });
-    
+
   });
 
   describe('startsWith', () => {
-    
+
     it('should call FirebaseQuery.startAt and FirebaseQuery.endAt', () => {
-      
+
       sinon.spy(queryRef.query(), 'startAt');
       // TODO: How to spy on the chained query
       //sinon.spy(queryRef.query().startAt(), 'endAt');
-      
+
       queryRef.startsWith('Davi');
-      
+
       // TODO: call startAt with the first character of the string
       expect(queryRef.query().startAt.calledOnce).to.be.ok;
       queryRef.query().startAt.restore();
-      
+
       // TODO: call endAt with the whole character plus "\uF8FF"
       // expect(queryRef.query().endAt.calledOnce).to.be.ok;
       // queryRef.query().endAt.restore();
-      
-    });    
-    
+
+    });
+
     it('should return a Firebase Query', () => {
       const query = queryRef.startsWith('D');
-      assert.equal(helpers.isFirebaseQuery(query), true);       
+      assert.equal(helpers.isFirebaseQuery(query), true);
     });
-    
+
   });
-  
+
   describe('between', () => {
-    
+
     it('should call FirebaseQuery.startAt and FirebaseQuery.endAt', () => {
       // TODO: call startAt with the valueOne
       // TODO: call endAt with valueTwo
       sinon.spy(queryRef.query(), 'startAt');
       queryRef.between(11, 99);
       expect(queryRef.query().startAt.calledOnce).to.be.ok;
-      queryRef.query().startAt.restore();      
-    }); 
-    
+      queryRef.query().startAt.restore();
+    });
+
     it('should return a Firebase Query', () => {
       const query = queryRef.between(1, 10);
-      assert.equal(helpers.isFirebaseQuery(query), true);       
+      assert.equal(helpers.isFirebaseQuery(query), true);
     });
-    
+
   });
-  
+
   describe('equalTo', () => {
-    
+
     it('should call FirebaseQuery.equalTo', () => {
       sinon.spy(queryRef.query(), 'equalTo');
       queryRef.equalTo('something awesome');
       expect(queryRef.query().equalTo.calledOnce).to.be.ok;
-      queryRef.query().equalTo.restore();       
-    }); 
-    
+      queryRef.query().equalTo.restore();
+    });
+
     it('should return a Firebase Query', () => {
       const query = queryRef.equalTo('someValue');
-      assert.equal(helpers.isFirebaseQuery(query), true);       
+      assert.equal(helpers.isFirebaseQuery(query), true);
     });
-    
-  });    
-  
+
+  });
+
 });

--- a/src/tests/unit/querybase-utils.spec.ts
+++ b/src/tests/unit/querybase-utils.spec.ts
@@ -1,19 +1,20 @@
-const _ = require('../../dist/querybase.umd').QuerybaseUtils;
-const assert = require('assert');
-const chai = require('chai');
-const firebaseServer = require('../firebaseServer');
-const helpers = require('../helpers');
+import { QuerybaseUtils as _ } from '../../entry';
+import * as firebaseServer from '../firebaseServer';
+import * as helpers from '../helpers';
+import * as assert from 'assert';
+import * as chai from 'chai';
+
 const should = chai.should();
 const expect = chai.expect;
 
 describe('QuerybaseUtils', () => {
-  
+
   const smallRecord = {
     zed: 'a',
     name: 'David',
     time: '5:01'
   };
-  
+
   const mediumRecord = {
     zed: 'a',
     zzzz: 'zzzz',
@@ -22,19 +23,19 @@ describe('QuerybaseUtils', () => {
     alpha: 'a',
     yogi: 'bear',
     jon: 'jon'
-  };  
-  
+  };
+
   const smallRecordKeys = _.keys(smallRecord);
   const smallRecordValues = _.values(smallRecord);
   const mediumRecordKeys = _.keys(mediumRecord);
   const mediumRecordValues = _.values(mediumRecord);
-  
+
   const sortedSmallRecord = {
     name: 'David',
     time: '5:01',
     zed: 'a'
   };
-  
+
   const sortedMediumRecord = {
     'alpha': 'a',
     'jon': 'jon',
@@ -43,95 +44,95 @@ describe('QuerybaseUtils', () => {
     'yogi': 'bear',
     'zed': 'a',
     'zzzz': 'zzzz'
-  };  
-  
+  };
+
   it('should exist', () => { expect(_).to.exist; })
-  
+
   describe('indexKey', () => {
-    
+
     it('should return the proper key', () => {
       assert.equal('~~', _.indexKey());
     });
-    
+
   });
-  
+
   describe('isString', () => {
-    
+
     it('should return true for a string value', () => {
       const result = _.isString('a string');
       assert.equal(result, true);
     });
-    
+
     it('should return false for a anything else', () => {
       const result = _.isString(22);
       assert.equal(result, false);
     });
-    
+
   });
-  
+
   describe('isCommonJS', () => {
     it('should return true, because this runtime is Node', () => {
       assert.equal(_.isCommonJS(), true);
     });
   });
-  
+
   describe('hasMultipleCriteria', () => {
-    
+
     it('should return true for more than one criteria key', () => {
       const criteriaKeys = ['age', 'location'];
       const hasMultiple = _.hasMultipleCriteria(criteriaKeys);
       assert.equal(hasMultiple, true);
     });
-    
+
     it('should return false for one criteria key', () => {
       const criteriaKeys = ['age'];
       const hasMultiple = _.hasMultipleCriteria(criteriaKeys);
       assert.equal(hasMultiple, false);
     });
-    
+
     it('should return false zero criteria keys', () => {
       const criteriaKeys = [];
       const hasMultiple = _.hasMultipleCriteria(criteriaKeys);
       assert.equal(hasMultiple, false);
     });
-    
+
   });
-  
+
   describe('getPathFromRef', () => {
-    
+
     it('should find the path from the Firebase reference', () => {
       const ref = firebaseServer.ref().child('items');
       assert.equal(_.getPathFromRef(ref), 'items');
     });
-    
+
     it('should find a two deep path from the Firebase reference', () => {
       const ref = firebaseServer.ref().child('items/1');
       assert.equal(_.getPathFromRef(ref), 'items/1');
     });
-    
+
     it('should find a three deep path from the Firebase reference', () => {
       const ref = firebaseServer.ref().child('items/1/2');
       assert.equal(_.getPathFromRef(ref), 'items/1/2');
     });
-        
+
   });
-  
+
   describe('merge', () => {
-    
+
     it('should merge two objects', () => {
-      
+
       const obj1 = { key: 'key' };
       const obj2 = { key2: 'key2', key3: 'key3'};
       const merged = _.merge(obj1, obj2);
       const expected = { key: 'key', key2: 'key2', key3: 'key3' };
       assert.deepEqual(expected, merged);
-      
+
     });
-    
+
   });
-  
+
   describe('lexicographicallySort', () => {
-    
+
     it('should lexicographically sort', () => {
       const sorted = smallRecordKeys.slice().sort(_.lexicographicallySort);
       assert.deepEqual(['name', 'time', 'zed'], sorted);
@@ -149,47 +150,47 @@ describe('QuerybaseUtils', () => {
         'zzzz'
        ];
       assert.deepEqual(expectedOrder, sorted);
-    });    
-    
-  });
-  
-  describe('getKeyIndexPositions', () => {
-    
-    it('should create an object with the index positions', () => {
-      
-      const indexOfKeys = _.getKeyIndexPositions(smallRecordKeys);
-      assert.deepEqual({ 'zed': 0, 'name': 1, 'time': 2 }, indexOfKeys);   
-      
     });
-     
+
   });
-  
+
+  describe('getKeyIndexPositions', () => {
+
+    it('should create an object with the index positions', () => {
+
+      const indexOfKeys = _.getKeyIndexPositions(smallRecordKeys);
+      assert.deepEqual({ 'zed': 0, 'name': 1, 'time': 2 }, indexOfKeys);
+
+    });
+
+  });
+
   describe('createSortedObject', () => {
-    
+
     it('should create a sorted object', () => {
       const sortedRecord = _.createSortedObject(smallRecordKeys, smallRecordValues);
-      assert.deepEqual(_.keys(sortedRecord), _.keys(sortedSmallRecord)); 
+      assert.deepEqual(_.keys(sortedRecord), _.keys(sortedSmallRecord));
     })
-    
+
     it('should create a sorted object', () => {
       const sortedRecord = _.createSortedObject(mediumRecordKeys, mediumRecordValues);
-      assert.deepEqual(_.keys(sortedMediumRecord), _.keys(sortedRecord)); 
-    })    
-    
+      assert.deepEqual(_.keys(sortedMediumRecord), _.keys(sortedRecord));
+    })
+
   });
-  
+
   describe('sortObjectLexicographically', () => {
-    
+
     it('sort an object lexicographically', () => {
       const sortedRecord = _.sortObjectLexicographically(smallRecord);
       assert.deepEqual(_.keys(sortedSmallRecord), _.keys(sortedRecord));
     });
-    
+
     it('sort an object lexicographically', () => {
       const sortedRecord = _.sortObjectLexicographically(mediumRecord);
       assert.deepEqual(_.keys(sortedMediumRecord), _.keys(sortedRecord));
-    });    
-    
+    });
+
   });
-    
+
 });

--- a/src/tests/unit/querybase.spec.ts
+++ b/src/tests/unit/querybase.spec.ts
@@ -1,13 +1,14 @@
 'use strict'
-const firebaseServer = require('../firebaseServer');
-const querybase = require('../../dist/querybase.umd');
+import * as firebaseServer from '../firebaseServer';
+import * as querybase from '../../entry';
+import * as helpers from '../helpers';
+import * as assert from 'assert';
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+
 const Querybase = querybase.Querybase;
 const QuerybaseQuery = querybase.QuerybaseQuery;
-const helpers = require('../helpers');
 const _ = querybase.QuerybaseUtils;
-const assert = require('assert');
-const chai = require('chai');
-const sinon = require('sinon');
 const expect = chai.expect;
 
 // disable warnings
@@ -45,12 +46,12 @@ describe('Querybase', () => {
   describe('constructor', () => {
 
     it('should throw if no Firebase ref is provided', () => {
-      const errorWrapper = () => new Querybase();
+      const errorWrapper = () => new Querybase(null, null);
       expect(errorWrapper).to.throw(Error);
     });
 
     it('should throw if no indexes are provided', () => {
-      const errorWrapper = () => new Querybase(ref);
+      const errorWrapper = () => new Querybase(ref, null);
       expect(errorWrapper).to.throw(Error);
     });
 

--- a/tests/helpers.d.ts
+++ b/tests/helpers.d.ts
@@ -1,9 +1,0 @@
-
-// interface Helpers {
-//   isFunction(fn: () => {}): Boolean;
-//   isFirebaseRef(ref: Firebase): Boolean;
-// }
-
-// declare module 'TestHelpers' {
-// 	export = Helpers;
-// }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,10 +1,11 @@
 {
     "compilerOptions": {
-        "module": "es6",
+        "module": "commonjs",
         "noImplicitAny": false,
-        "removeComments": true,
+        "removeComments": false,
         "preserveConstEnums": true,
-        "outDir": "es6",
+        "outDir": "dist",
+        "allowJs": true,
         "sourceMap": true,
         "typeRoots": [
             "node_modules/@types"
@@ -16,6 +17,6 @@
         ]
     },
     "include": [
-        "./src/**/*.ts"
+        "./src/**/*"
     ]
 }


### PR DESCRIPTION
Tests were previously in JS but relied on the awesome code complete in Visual Studio Code. This PR changes them to TS. This involved changing the build process to convert the files to CJS and then test.